### PR TITLE
Add interface for db layer

### DIFF
--- a/src/application/core/domain/repositories/in-memory-receipt-repository.ts
+++ b/src/application/core/domain/repositories/in-memory-receipt-repository.ts
@@ -2,41 +2,23 @@ import { Receipt } from '../../../../types/domain/receipt';
 import { GetPointsResponse } from '../../../../types/http/get-receipt-points';
 
 /**
- * A repository for storing receipts in memory.
- * Data is stored in a Map object for efficient key-value management.
- * Maps each receipt ID (string) to an object containing the receipt and its associated points.
+ * Interface for a receipt repository.
+ * It defines methods to save a receipt and retrieve receipt points.
  */
-export class InMemoryReceiptRepository {
+export interface IReceiptRepository {
   /**
-   * In-memory store for receipts.
-   */
-  private receipts: Map<string, { receipt: Receipt; points: number }> =
-    new Map();
-
-  /**
-   * Saves a receipt to the in-memory store.
-   * @param {string} id
-   * @param {Receipt} receipt
-   * @param {number} points
+   * Saves a receipt to the repository.
+   * @param {string} id - The receipt ID.
+   * @param {Receipt} receipt - The receipt data.
+   * @param {number} points - The points associated with the receipt.
    * @returns {string} The id of the stored receipt.
    */
-  save(id: string, receipt: Receipt, points: number): string {
-    this.receipts.set(id, { receipt, points });
-    return id;
-  }
+  save(id: string, receipt: Receipt, points: number): string;
 
   /**
-   * Finds a receipt by its ID.
-   * Retrieves the stored receipt and its associated points from the in-memory store.
-   * @param {string} id
-   * @returns {GetPointsResponse | null}
-   * An object containing the receipt and points if found, otherwise null.
+   * Finds a receipt by its ID and returns its associated points.
+   * @param {string} id - The receipt ID.
+   * @returns {GetPointsResponse | null} The points associated with the receipt, or null if not found.
    */
-  find(id: string): GetPointsResponse | null {
-    const savedReceipt = this.receipts.get(id);
-    if (!savedReceipt?.points) {
-      return null;
-    }
-    return { points: savedReceipt.points };
-  }
+  find(id: string): GetPointsResponse | null;
 }

--- a/src/application/core/domain/services/receipt-service-factory.ts
+++ b/src/application/core/domain/services/receipt-service-factory.ts
@@ -1,5 +1,5 @@
+import { InMemoryReceiptDatabase } from '../../../../infrastructure/database/in-memory-database';
 import { PointsCalculator } from '../../utils/points-calculator';
-import { InMemoryReceiptRepository } from '../repositories/InMemoryReceiptRepository';
 import { ReceiptService } from './receipt-service';
 
 /**
@@ -8,7 +8,7 @@ import { ReceiptService } from './receipt-service';
  * @returns {ReceiptService}
  */
 export const getReceiptService = (): ReceiptService => {
-  const inMemoryReceiptRepository = new InMemoryReceiptRepository();
+  const inMemoryReceiptRepository = new InMemoryReceiptDatabase();
   const pointsCalculator = new PointsCalculator();
 
   return new ReceiptService(inMemoryReceiptRepository, pointsCalculator);

--- a/src/application/core/domain/services/receipt-service.ts
+++ b/src/application/core/domain/services/receipt-service.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'crypto';
 import { Receipt } from '../../../../types/domain/receipt';
 import { PointsCalculator } from '../../utils/points-calculator';
-import { InMemoryReceiptRepository } from '../repositories/InMemoryReceiptRepository';
 import { HTTPError } from '../../../../interface/errors/http-error';
+import { InMemoryReceiptDatabase } from '../../../../infrastructure/database/in-memory-database';
 
 /**
  * Service class that handles the core business logic for processing receipts.
@@ -16,7 +16,7 @@ export class ReceiptService {
    * @param pointsCalculator
    */
   constructor(
-    private repository: InMemoryReceiptRepository,
+    private repository: InMemoryReceiptDatabase,
     private pointsCalculator: PointsCalculator
   ) {}
 

--- a/src/infrastructure/database/in-memory-database.ts
+++ b/src/infrastructure/database/in-memory-database.ts
@@ -1,0 +1,43 @@
+import { IReceiptRepository } from '../../application/core/domain/repositories/in-memory-receipt-repository';
+import { Receipt } from '../../types/domain/receipt';
+import { GetPointsResponse } from '../../types/http/get-receipt-points';
+
+/**
+ * A repository for storing receipts in memory.
+ * Data is stored in a Map object for efficient key-value management.
+ * Maps each receipt ID (string) to an object containing the receipt and its associated points.
+ */
+export class InMemoryReceiptDatabase implements IReceiptRepository {
+  /**
+   * In-memory store for receipts.
+   */
+  private receipts: Map<string, { receipt: Receipt; points: number }> =
+    new Map();
+
+  /**
+   * Saves a receipt to the in-memory store.
+   * @param {string} id
+   * @param {Receipt} receipt
+   * @param {number} points
+   * @returns {string} The id of the stored receipt.
+   */
+  save(id: string, receipt: Receipt, points: number): string {
+    this.receipts.set(id, { receipt, points });
+    return id;
+  }
+
+  /**
+   * Finds a receipt by its ID.
+   * Retrieves the stored receipt and its associated points from the in-memory store.
+   * @param {string} id
+   * @returns {GetPointsResponse | null}
+   * An object containing the receipt and points if found, otherwise null.
+   */
+  find(id: string): GetPointsResponse | null {
+    const savedReceipt = this.receipts.get(id);
+    if (!savedReceipt?.points) {
+      return null;
+    }
+    return { points: savedReceipt.points };
+  }
+}

--- a/src/infrastructure/database/in-memory-receipt-database.test.ts
+++ b/src/infrastructure/database/in-memory-receipt-database.test.ts
@@ -1,8 +1,8 @@
-import { Receipt } from '../../../../types/domain/receipt';
-import { InMemoryReceiptRepository } from './in-memory-receipt-repository';
+import { Receipt } from '../../types/domain/receipt';
+import { InMemoryReceiptDatabase } from './in-memory-database';
 
 describe('InMemoryReceiptRepository', () => {
-  let repository: InMemoryReceiptRepository;
+  let repository: InMemoryReceiptDatabase;
 
   const mockReceipt: Receipt = {
     retailer: 'Target',
@@ -19,7 +19,7 @@ describe('InMemoryReceiptRepository', () => {
   };
 
   beforeEach(() => {
-    repository = new InMemoryReceiptRepository();
+    repository = new InMemoryReceiptDatabase();
   });
 
   describe('save', () => {


### PR DESCRIPTION
- Moved database class to the infrastructure directory
- Created a repository interface

Advantages of this structure:
- Decouples the structure of the class from the actual implementation
- Can define a new database that conforms to the interface in the future
- Easier to mock for testing