### PR TITLE
Add Swagger Docs and OpenAPI JSON Spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@fastify/swagger": "^9.4.0",
+        "@fastify/swagger-ui": "^5.1.0",
         "fastify": "^5.1.0"
       },
       "devDependencies": {
@@ -752,6 +754,12 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.0.0.tgz",
+      "integrity": "sha512-/Sce/kBzuTxIq5tJh85nVNOq9wKD8s+viIgX0fFMDBdw95gnpf53qmF1oBgJym3cPFliWUuSloVg/1w/rH0FcQ==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.1.tgz",
@@ -785,6 +793,118 @@
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "node_modules/@fastify/send": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-3.2.0.tgz",
+      "integrity": "sha512-qF4TIEMjqk92jrOXjcqBrkk+HOXE70AwDKas9/AweFslbvSq0o1JEAHzC7YlggBaj4bN9pU70XIPyseEJ6vlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "^2.0.0",
+        "mime": "^3"
+      }
+    },
+    "node_modules/@fastify/send/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-8.0.3.tgz",
+      "integrity": "sha512-GHSoOVDIxEYEeVR5l044bRCuAKDErD/+9VE+Z9fnaTRr+DDz0Avrm4kKai1mHbPx6C0U7BVNthjd/gcMquZZUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/send": "^3.2.0",
+        "content-disposition": "^0.5.4",
+        "fastify-plugin": "^5.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^11.0.0"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/glob": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@fastify/static/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@fastify/swagger": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@fastify/swagger/-/swagger-9.4.0.tgz",
+      "integrity": "sha512-3hF7asqyNfu41aeDA/ATlIG0RY4XizgaDqPR0nc1Unt3EiXWjkVMiELLaH5WZKNvB4BA/5Wovxdin7N4ii7YHw==",
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "json-schema-resolver": "^2.0.0",
+        "openapi-types": "^12.1.3",
+        "rfdc": "^1.3.1",
+        "yaml": "^2.4.2"
+      }
+    },
+    "node_modules/@fastify/swagger-ui": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/swagger-ui/-/swagger-ui-5.1.0.tgz",
+      "integrity": "sha512-XWb+zWz0vlP4QIXbF2xo/n9XuOjNF5aRdQ+0AiBXY9nlIuoTYU1ZXCkXNStdnM/sOdnDy8Q1vsxZ2RsN7XivQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/static": "^8.0.0",
+        "fastify-plugin": "^5.0.0",
+        "openapi-types": "^12.1.3",
+        "rfdc": "^1.3.1",
+        "yaml": "^2.4.1"
       }
     },
     "node_modules/@humanfs/core": {
@@ -851,6 +971,102 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1357,6 +1573,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1912,7 +2137,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1922,7 +2146,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2132,7 +2355,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -2370,7 +2592,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2383,7 +2604,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -2415,6 +2635,18 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2472,7 +2704,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2487,7 +2718,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2561,6 +2791,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2602,6 +2841,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -2642,7 +2887,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -2687,6 +2931,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3084,6 +3334,12 @@
         "toad-cache": "^3.7.0"
       }
     },
+    "node_modules/fastify-plugin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.0.1.tgz",
+      "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==",
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -3213,6 +3469,34 @@
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/form-data": {
       "version": "4.0.1",
@@ -3502,6 +3786,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -3585,7 +3885,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -3634,7 +3933,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3690,7 +3988,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -3762,6 +4059,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
+      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jake": {
@@ -4422,6 +4734,23 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "node_modules/json-schema-resolver": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-resolver/-/json-schema-resolver-2.0.0.tgz",
+      "integrity": "sha512-pJ4XLQP4Q9HTxl6RVDLJ8Cyh1uitSs0CzDBAz1uoJ4sRD/Bk7cFSXL1FUXDW3zJ7YnfliJx6eu8Jn283bpZ4Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "rfdc": "^1.1.4",
+        "uri-js": "^4.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/Eomm/json-schema-resolver?sponsor=1"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -4683,11 +5012,19 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -4782,6 +5119,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4842,6 +5185,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4898,7 +5247,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4910,6 +5258,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5138,7 +5511,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5349,6 +5721,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-regex2": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-4.0.0.tgz",
@@ -5409,11 +5801,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5426,7 +5823,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5544,6 +5940,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -5562,7 +5967,21 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5577,7 +5996,19 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5731,6 +6162,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5958,7 +6398,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -6011,7 +6450,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6038,6 +6476,24 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6088,6 +6544,18 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@fastify/swagger": "^9.4.0",
+    "@fastify/swagger-ui": "^5.1.0",
     "fastify": "^5.1.0"
   },
   "devDependencies": {

--- a/src/infrastructure/config/server-config.ts
+++ b/src/infrastructure/config/server-config.ts
@@ -11,11 +11,11 @@ export const startServer = async (fastify: FastifyInstance) => {
     // Wait for Fastify to be fully ready, including all plugins (Swagger, etc.)
     await fastify.ready();
 
-    // Optionally, log or access the OpenAPI schema once the server is ready
+    // logging the openapi schema on start up
     const openapiSchema = fastify.swagger();
     console.log('OpenAPI Schema:', openapiSchema);
 
-    // Now, start the server after everything is ready
+    // start the server after everything is ready
     const address = await fastify.listen({ port: 3000, host: '0.0.0.0' });
     console.log(`Server listening on: ${address}`);
   } catch (err) {

--- a/src/infrastructure/config/server-config.ts
+++ b/src/infrastructure/config/server-config.ts
@@ -7,17 +7,20 @@ import { FastifyInstance } from 'fastify';
  * @returns {Promise<void>} A promise that resolves when the server starts.
  */
 export const startServer = async (fastify: FastifyInstance) => {
-  // Listen on port 3000 and bind to all network interfaces (0.0.0.0)
-  fastify.listen(
-    { port: 3000, host: '0.0.0.0' },
-    (err: Error | null, address: string) => {
-      if (err) {
-        // Log the error and terminate the process if the server fails to start
-        fastify.log.error(err);
-        process.exit(1);
-      }
-      // Log the server's address once it starts successfully
-      console.log(`Server listening on: ${address}`);
-    }
-  );
+  try {
+    // Wait for Fastify to be fully ready, including all plugins (Swagger, etc.)
+    await fastify.ready();
+
+    // Optionally, log or access the OpenAPI schema once the server is ready
+    const openapiSchema = fastify.swagger();
+    console.log('OpenAPI Schema:', openapiSchema);
+
+    // Now, start the server after everything is ready
+    const address = await fastify.listen({ port: 3000, host: '0.0.0.0' });
+    console.log(`Server listening on: ${address}`);
+  } catch (err) {
+    // If there’s any error during startup (including plugin registration)
+    fastify.log.error(err);
+    process.exit(1);
+  }
 };

--- a/src/infrastructure/config/swagger-config.ts
+++ b/src/infrastructure/config/swagger-config.ts
@@ -12,6 +12,7 @@ import swaggerUi from '@fastify/swagger-ui'; // Import the Swagger UI plugin for
  * @param fastify - The Fastify instance to register the plugins with.
  */
 export async function registerSwagger(fastify: FastifyInstance) {
+  // Register the swagger plugin, this generates the openApi json spec
   await fastify.register(swagger, {
     openapi: {
       info: {

--- a/src/infrastructure/config/swagger-config.ts
+++ b/src/infrastructure/config/swagger-config.ts
@@ -1,119 +1,36 @@
 import { FastifyInstance } from 'fastify';
-import fastifySwagger from '@fastify/swagger';
-import fastifySwaggerUi from '@fastify/swagger-ui';
+import swagger from '@fastify/swagger';
+import swaggerUi from '@fastify/swagger-ui';
 
-export const registerSwagger = async (fastify: FastifyInstance) => {
-  // Register Swagger plugin to generate OpenAPI schema
-  fastify.register(fastifySwagger, {
+export async function registerSwagger(fastify: FastifyInstance) {
+  // Register Swagger
+  await fastify.register(swagger, {
     openapi: {
-      openapi: '3.0.0', // Added openapi field to define version explicitly
       info: {
         title: 'Receipt Processor',
         description: 'My Fastify API that processes receipts',
         version: '1.0.0',
       },
-      servers: [{ url: 'http://localhost:3000/v1' }],
-      tags: [
-      { name: 'receipt', description: 'Receipt related endpoints' },
-    ],
+      servers: [
+        {
+          url: 'http://localhost:3000/v1',
+        },
+      ],
+      tags: [{ name: 'receipt', description: 'Receipt related endpoints' }],
+    },
+    // Remove the 'mode' property and use standard OpenAPI options
+    transform: (schema) => {
+      // Optional: Add custom schema transformations if needed
+      return schema;
     },
   });
 
-  // Register Swagger UI to serve the UI at /docs
-  fastify.register(fastifySwaggerUi, {
+  // Register Swagger UI
+  await fastify.register(swaggerUi, {
     routePrefix: '/docs',
     uiConfig: {
-      docExpansion: 'none', // Adjust UI settings here
-      deepLinking: false,
+      docExpansion: 'full',
+      deepLinking: true,
     },
   });
-
-  await fastify.ready()
-  fastify.swagger()
-};
-
-export const swaggerExample = async (fastify: FastifyInstance) => {
-
-await fastify.register(require('@fastify/swagger'), {
-  openapi: {
-    openapi: '3.0.0',
-    info: {
-      title: 'Test swagger',
-      description: 'Testing the Fastify swagger API',
-      version: '0.1.0'
-    },
-    servers: [
-      {
-        url: 'http://localhost:3000',
-        description: 'Development server'
-      }
-    ],
-    tags: [
-      { name: 'user', description: 'User related end-points' },
-      { name: 'code', description: 'Code related end-points' }
-    ],
-    components: {
-      securitySchemes: {
-        apiKey: {
-          type: 'apiKey',
-          name: 'apiKey',
-          in: 'header'
-        }
-      }
-    },
-    externalDocs: {
-      url: 'https://swagger.io',
-      description: 'Find more info here'
-    }
-  }
-})
-
-fastify.put('/some-route/:id', {
-  schema: {
-    description: 'post some data',
-    tags: ['user', 'code'],
-    summary: 'qwerty',
-    security: [{ apiKey: [] }],
-    params: {
-      type: 'object',
-      properties: {
-        id: {
-          type: 'string',
-          description: 'user id'
-        }
-      }
-    },
-    body: {
-      type: 'object',
-      properties: {
-        hello: { type: 'string' },
-        obj: {
-          type: 'object',
-          properties: {
-            some: { type: 'string' }
-          }
-        }
-      }
-    },
-    response: {
-      201: {
-        description: 'Successful response',
-        type: 'object',
-        properties: {
-          hello: { type: 'string' }
-        }
-      },
-      default: {
-        description: 'Default response',
-        type: 'object',
-        properties: {
-          foo: { type: 'string' }
-        }
-      }
-    }
-  }
-}, (req, reply) => { })
-
-await fastify.ready()
-fastify.swagger()
 }

--- a/src/infrastructure/config/swagger-config.ts
+++ b/src/infrastructure/config/swagger-config.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from 'fastify';
 import fastifySwagger from '@fastify/swagger';
 import fastifySwaggerUi from '@fastify/swagger-ui';
 
-export const registerSwagger = (fastify: FastifyInstance) => {
+export const registerSwagger = async (fastify: FastifyInstance) => {
   // Register Swagger plugin to generate OpenAPI schema
   fastify.register(fastifySwagger, {
     openapi: {
@@ -14,8 +14,8 @@ export const registerSwagger = (fastify: FastifyInstance) => {
       },
       servers: [{ url: 'http://localhost:3000/v1' }],
       tags: [
-        { name: 'receipt', description: 'Receipt related endpoints' },
-      ],
+      { name: 'receipt', description: 'Receipt related endpoints' },
+    ],
     },
   });
 
@@ -27,4 +27,93 @@ export const registerSwagger = (fastify: FastifyInstance) => {
       deepLinking: false,
     },
   });
+
+  await fastify.ready()
+  fastify.swagger()
 };
+
+export const swaggerExample = async (fastify: FastifyInstance) => {
+
+await fastify.register(require('@fastify/swagger'), {
+  openapi: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Test swagger',
+      description: 'Testing the Fastify swagger API',
+      version: '0.1.0'
+    },
+    servers: [
+      {
+        url: 'http://localhost:3000',
+        description: 'Development server'
+      }
+    ],
+    tags: [
+      { name: 'user', description: 'User related end-points' },
+      { name: 'code', description: 'Code related end-points' }
+    ],
+    components: {
+      securitySchemes: {
+        apiKey: {
+          type: 'apiKey',
+          name: 'apiKey',
+          in: 'header'
+        }
+      }
+    },
+    externalDocs: {
+      url: 'https://swagger.io',
+      description: 'Find more info here'
+    }
+  }
+})
+
+fastify.put('/some-route/:id', {
+  schema: {
+    description: 'post some data',
+    tags: ['user', 'code'],
+    summary: 'qwerty',
+    security: [{ apiKey: [] }],
+    params: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'user id'
+        }
+      }
+    },
+    body: {
+      type: 'object',
+      properties: {
+        hello: { type: 'string' },
+        obj: {
+          type: 'object',
+          properties: {
+            some: { type: 'string' }
+          }
+        }
+      }
+    },
+    response: {
+      201: {
+        description: 'Successful response',
+        type: 'object',
+        properties: {
+          hello: { type: 'string' }
+        }
+      },
+      default: {
+        description: 'Default response',
+        type: 'object',
+        properties: {
+          foo: { type: 'string' }
+        }
+      }
+    }
+  }
+}, (req, reply) => { })
+
+await fastify.ready()
+fastify.swagger()
+}

--- a/src/infrastructure/config/swagger-config.ts
+++ b/src/infrastructure/config/swagger-config.ts
@@ -1,9 +1,17 @@
-import { FastifyInstance } from 'fastify';
-import swagger from '@fastify/swagger';
-import swaggerUi from '@fastify/swagger-ui';
+import { FastifyInstance } from 'fastify'; // Import FastifyInstance type for type safety
+import swagger from '@fastify/swagger'; // Import the Fastify Swagger plugin for OpenAPI support
+import swaggerUi from '@fastify/swagger-ui'; // Import the Swagger UI plugin for rendering API docs in the browser
 
+/**
+ * Registers Swagger documentation and Swagger UI for the Fastify instance.
+ *
+ * This function configures the OpenAPI documentation for the API and sets up a route
+ * to view it through Swagger UI. This makes it easy to document and interact with
+ * the API endpoints for developers and users.
+ *
+ * @param fastify - The Fastify instance to register the plugins with.
+ */
 export async function registerSwagger(fastify: FastifyInstance) {
-  // Register Swagger
   await fastify.register(swagger, {
     openapi: {
       info: {
@@ -13,24 +21,18 @@ export async function registerSwagger(fastify: FastifyInstance) {
       },
       servers: [
         {
-          url: 'http://localhost:3000/v1',
+          url: 'http://localhost:3000/v1', // The base URL for the API, where 'v1' is the version
         },
       ],
-      tags: [{ name: 'receipt', description: 'Receipt related endpoints' }],
-    },
-    // Remove the 'mode' property and use standard OpenAPI options
-    transform: (schema) => {
-      // Optional: Add custom schema transformations if needed
-      return schema;
+      tags: [{ name: 'Receipt', description: '/receipt' }],
     },
   });
 
-  // Register Swagger UI
+  // Register the Swagger UI plugin to serve the interactive documentation interface
   await fastify.register(swaggerUi, {
-    routePrefix: '/docs',
+    routePrefix: '/docs', // The route where Swagger UI will be available
     uiConfig: {
-      docExpansion: 'full',
-      deepLinking: true,
+      deepLinking: true, // Allow linking directly to specific parts of the documentation
     },
   });
 }

--- a/src/infrastructure/config/swagger-config.ts
+++ b/src/infrastructure/config/swagger-config.ts
@@ -1,0 +1,30 @@
+import { FastifyInstance } from 'fastify';
+import fastifySwagger from '@fastify/swagger';
+import fastifySwaggerUi from '@fastify/swagger-ui';
+
+export const registerSwagger = (fastify: FastifyInstance) => {
+  // Register Swagger plugin to generate OpenAPI schema
+  fastify.register(fastifySwagger, {
+    openapi: {
+      openapi: '3.0.0', // Added openapi field to define version explicitly
+      info: {
+        title: 'Receipt Processor',
+        description: 'My Fastify API that processes receipts',
+        version: '1.0.0',
+      },
+      servers: [{ url: 'http://localhost:3000/v1' }],
+      tags: [
+        { name: 'receipt', description: 'Receipt related endpoints' },
+      ],
+    },
+  });
+
+  // Register Swagger UI to serve the UI at /docs
+  fastify.register(fastifySwaggerUi, {
+    routePrefix: '/docs',
+    uiConfig: {
+      docExpansion: 'none', // Adjust UI settings here
+      deepLinking: false,
+    },
+  });
+};

--- a/src/interface/hooks/version-redirect-hook.ts
+++ b/src/interface/hooks/version-redirect-hook.ts
@@ -14,6 +14,12 @@ export const versionRedirectHook = (
   reply: FastifyReply,
   done: HookHandlerDoneFunction
 ) => {
+  // Exclude the /docs or /v1/docs route from version redirection
+  if (request.url.startsWith('/docs')) {
+    done(); // Don't redirect for Swagger UI
+    return;
+  }
+
   // Check if the request URL already includes a version prefix (e.g., /v1/)
   const versionedRoute = /^\/v\d+\//.test(request.url);
 

--- a/src/interface/routes/index.ts
+++ b/src/interface/routes/index.ts
@@ -8,6 +8,7 @@ import { API_VERSION_ONE_PREFIX } from '../../constants';
  * Routes are grouped under versioned prefixes for better API version management.
  *
  * @param {FastifyInstance} fastify - The Fastify server instance to register routes on.
+ * @returns {void}
  */
 export const registerRoutes = (fastify: FastifyInstance) => {
   fastify.register(processReceiptRoute, {

--- a/src/interface/routes/v1/receipts/:id/points/open-api-schema.ts
+++ b/src/interface/routes/v1/receipts/:id/points/open-api-schema.ts
@@ -1,0 +1,28 @@
+export const receiptPointsOpenApiSchema = {
+  schema: {
+    description: 'Get points for a specific receipt',
+    tags: ['Receipt'], // This helps with Swagger organization
+    params: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Receipt ID',
+        },
+      },
+      required: ['id'],
+    },
+    response: {
+      200: {
+        type: 'object',
+        properties: {
+          points: {
+            type: 'integer',
+            description: 'Number of points for the receipt',
+          },
+        },
+        required: ['points'],
+      },
+    },
+  },
+};

--- a/src/interface/routes/v1/receipts/:id/points/open-api-schema.ts
+++ b/src/interface/routes/v1/receipts/:id/points/open-api-schema.ts
@@ -1,7 +1,7 @@
 export const receiptPointsOpenApiSchema = {
   schema: {
     description: 'Get points for a specific receipt',
-    tags: ['Receipt'], // This helps with Swagger organization
+    tags: ['Receipt'],
     params: {
       type: 'object',
       properties: {

--- a/src/interface/routes/v1/receipts/:id/points/route.ts
+++ b/src/interface/routes/v1/receipts/:id/points/route.ts
@@ -1,40 +1,47 @@
 import { FastifyInstance } from 'fastify';
-import { API_POINTS_PATH, API_RECEIPTS_PATH } from '../../../../../../constants';
+import {
+  API_POINTS_PATH,
+  API_RECEIPTS_PATH,
+} from '../../../../../../constants';
 import { GetPointsResponse } from '../../../../../../types/http/get-receipt-points';
 import { getReceiptPointsController } from '../../../../../controllers/get-receipt-points/get-receipt-points-controller';
 
 const RECEIPT_POINTS_URL_PATH = `/${API_RECEIPTS_PATH}/:id/${API_POINTS_PATH}`;
 
 export default async function getPointsRoute(fastify: FastifyInstance) {
-  // Add OpenAPI schema for the route documentation
-  fastify.get<{ Params: { id: string }; Reply: GetPointsResponse }>(
+  fastify.get<{
+    Params: { id: string };
+    Reply: GetPointsResponse;
+  }>(
     RECEIPT_POINTS_URL_PATH,
     {
       schema: {
-        params: { 
+        description: 'Get points for a specific receipt',
+        tags: ['receipt'], // This helps with Swagger organization
+        params: {
           type: 'object',
           properties: {
-            id: { type: 'string' },
+            id: {
+              type: 'string',
+              description: 'Receipt ID',
+            },
           },
+          required: ['id'],
         },
         response: {
           200: {
-            description: 'Successful response with points',
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    points: { type: 'integer' },
-                  },
-                },
+            type: 'object',
+            properties: {
+              points: {
+                type: 'integer',
+                description: 'Number of points for the receipt',
               },
             },
+            required: ['points'],
           },
         },
       },
     },
     getReceiptPointsController
   );
-
 }

--- a/src/interface/routes/v1/receipts/:id/points/route.ts
+++ b/src/interface/routes/v1/receipts/:id/points/route.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../../../../constants';
 import { GetPointsResponse } from '../../../../../../types/http/get-receipt-points';
 import { getReceiptPointsController } from '../../../../../controllers/get-receipt-points/get-receipt-points-controller';
+import { receiptPointsOpenApiSchema } from './open-api-schema';
 
 const RECEIPT_POINTS_URL_PATH = `/${API_RECEIPTS_PATH}/:id/${API_POINTS_PATH}`;
 
@@ -14,34 +15,7 @@ export default async function getPointsRoute(fastify: FastifyInstance) {
     Reply: GetPointsResponse;
   }>(
     RECEIPT_POINTS_URL_PATH,
-    {
-      schema: {
-        description: 'Get points for a specific receipt',
-        tags: ['receipt'], // This helps with Swagger organization
-        params: {
-          type: 'object',
-          properties: {
-            id: {
-              type: 'string',
-              description: 'Receipt ID',
-            },
-          },
-          required: ['id'],
-        },
-        response: {
-          200: {
-            type: 'object',
-            properties: {
-              points: {
-                type: 'integer',
-                description: 'Number of points for the receipt',
-              },
-            },
-            required: ['points'],
-          },
-        },
-      },
-    },
+    receiptPointsOpenApiSchema,
     getReceiptPointsController
   );
 }

--- a/src/interface/routes/v1/receipts/:id/points/route.ts
+++ b/src/interface/routes/v1/receipts/:id/points/route.ts
@@ -1,20 +1,40 @@
 import { FastifyInstance } from 'fastify';
-import {
-  API_POINTS_PATH,
-  API_RECEIPTS_PATH,
-} from '../../../../../../constants';
+import { API_POINTS_PATH, API_RECEIPTS_PATH } from '../../../../../../constants';
 import { GetPointsResponse } from '../../../../../../types/http/get-receipt-points';
 import { getReceiptPointsController } from '../../../../../controllers/get-receipt-points/get-receipt-points-controller';
 
 const RECEIPT_POINTS_URL_PATH = `/${API_RECEIPTS_PATH}/:id/${API_POINTS_PATH}`;
 
-/**
- * A plugin that provides encapsulated routes
- * @param {FastifyInstance} fastify encapsulated fastify instance
- */
 export default async function getPointsRoute(fastify: FastifyInstance) {
   fastify.get<{ Params: { id: string }; Reply: GetPointsResponse }>(
     RECEIPT_POINTS_URL_PATH,
+    {
+      schema: {
+        description: 'Retrieve the points for the specified receipt ID.',
+        tags: ['receipt'],
+        params: { // Here, we define the parameters in the URL path
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        response: {
+          200: {
+            description: 'Successful response with points',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    points: { type: 'integer' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     getReceiptPointsController
   );
 }

--- a/src/interface/routes/v1/receipts/:id/points/route.ts
+++ b/src/interface/routes/v1/receipts/:id/points/route.ts
@@ -9,6 +9,10 @@ import { receiptPointsOpenApiSchema } from './open-api-schema';
 
 const RECEIPT_POINTS_URL_PATH = `/${API_RECEIPTS_PATH}/:id/${API_POINTS_PATH}`;
 
+/**
+ * A plugin that provides encapsulated routes
+ * @param {FastifyInstance} fastify encapsulated fastify instance
+ */
 export default async function getPointsRoute(fastify: FastifyInstance) {
   fastify.get<{
     Params: { id: string };

--- a/src/interface/routes/v1/receipts/:id/points/route.ts
+++ b/src/interface/routes/v1/receipts/:id/points/route.ts
@@ -6,13 +6,12 @@ import { getReceiptPointsController } from '../../../../../controllers/get-recei
 const RECEIPT_POINTS_URL_PATH = `/${API_RECEIPTS_PATH}/:id/${API_POINTS_PATH}`;
 
 export default async function getPointsRoute(fastify: FastifyInstance) {
+  // Add OpenAPI schema for the route documentation
   fastify.get<{ Params: { id: string }; Reply: GetPointsResponse }>(
     RECEIPT_POINTS_URL_PATH,
     {
       schema: {
-        description: 'Retrieve the points for the specified receipt ID.',
-        tags: ['receipt'],
-        params: { // Here, we define the parameters in the URL path
+        params: { 
           type: 'object',
           properties: {
             id: { type: 'string' },
@@ -37,4 +36,5 @@ export default async function getPointsRoute(fastify: FastifyInstance) {
     },
     getReceiptPointsController
   );
+
 }

--- a/src/interface/routes/v1/receipts/process/open-api-schema.ts
+++ b/src/interface/routes/v1/receipts/process/open-api-schema.ts
@@ -1,9 +1,9 @@
 export const processReceiptOpenApiSchema = {
   schema: {
     description: 'Process a receipt and return an ID.',
-    tags: ['Receipt'], // This helps with Swagger organization
+    tags: ['Receipt'],
     body: {
-      // Here, we define the request body schema for the POST request
+      // the request body schema for the POST request
       type: 'object',
       properties: {
         retailer: { type: 'string' },

--- a/src/interface/routes/v1/receipts/process/open-api-schema.ts
+++ b/src/interface/routes/v1/receipts/process/open-api-schema.ts
@@ -1,0 +1,41 @@
+export const processReceiptOpenApiSchema = {
+  schema: {
+    description: 'Process a receipt and return an ID.',
+    tags: ['Receipt'], // This helps with Swagger organization
+    body: {
+      // Here, we define the request body schema for the POST request
+      type: 'object',
+      properties: {
+        retailer: { type: 'string' },
+        purchaseDate: { type: 'string' },
+        purchaseTime: { type: 'string' },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              shortDescription: { type: 'string' },
+              price: { type: 'string' },
+            },
+          },
+        },
+        total: { type: 'string' },
+      },
+    },
+    response: {
+      200: {
+        description: 'Successful response with receipt ID',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/interface/routes/v1/receipts/process/route.ts
+++ b/src/interface/routes/v1/receipts/process/route.ts
@@ -7,6 +7,10 @@ import { processReceiptOpenApiSchema } from './open-api-schema';
 
 const PROCESS_RECEIPT_URL_PATH = `/${API_RECEIPTS_PATH}/${API_PROCESS_PATH}`;
 
+/**
+ * A plugin that provides encapsulated routes
+ * @param {FastifyInstance} fastify encapsulated fastify instance
+ */
 export default async function processReceiptRoute(fastify: FastifyInstance) {
   fastify.post<{ Body: Receipt; Reply: PostReceiptResponse }>(
     PROCESS_RECEIPT_URL_PATH,

--- a/src/interface/routes/v1/receipts/process/route.ts
+++ b/src/interface/routes/v1/receipts/process/route.ts
@@ -3,52 +3,14 @@ import { API_RECEIPTS_PATH, API_PROCESS_PATH } from '../../../../../constants';
 import { Receipt } from '../../../../../types/domain/receipt';
 import { PostReceiptResponse } from '../../../../../types/http/process-receipt';
 import { processReceiptController } from '../../../../controllers/process-receipt/process-receipt-controller';
+import { processReceiptOpenApiSchema } from './open-api-schema';
 
 const PROCESS_RECEIPT_URL_PATH = `/${API_RECEIPTS_PATH}/${API_PROCESS_PATH}`;
 
 export default async function processReceiptRoute(fastify: FastifyInstance) {
   fastify.post<{ Body: Receipt; Reply: PostReceiptResponse }>(
     PROCESS_RECEIPT_URL_PATH,
-    {
-      schema: {
-        description: 'Process a receipt and return an ID.',
-        body: {
-          // Here, we define the request body schema for the POST request
-          type: 'object',
-          properties: {
-            retailer: { type: 'string' },
-            purchaseDate: { type: 'string' },
-            purchaseTime: { type: 'string' },
-            items: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  shortDescription: { type: 'string' },
-                  price: { type: 'string' },
-                },
-              },
-            },
-            total: { type: 'string' },
-          },
-        },
-        response: {
-          200: {
-            description: 'Successful response with receipt ID',
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    id: { type: 'string' },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
+    processReceiptOpenApiSchema,
     processReceiptController
   );
 }

--- a/src/interface/routes/v1/receipts/process/route.ts
+++ b/src/interface/routes/v1/receipts/process/route.ts
@@ -12,7 +12,8 @@ export default async function processReceiptRoute(fastify: FastifyInstance) {
     {
       schema: {
         description: 'Process a receipt and return an ID.',
-        body: { // Here, we define the request body schema for the POST request
+        body: {
+          // Here, we define the request body schema for the POST request
           type: 'object',
           properties: {
             retailer: { type: 'string' },

--- a/src/interface/routes/v1/receipts/process/route.ts
+++ b/src/interface/routes/v1/receipts/process/route.ts
@@ -1,18 +1,53 @@
 import { FastifyInstance } from 'fastify';
-import { API_PROCESS_PATH, API_RECEIPTS_PATH } from '../../../../../constants';
+import { API_RECEIPTS_PATH, API_PROCESS_PATH } from '../../../../../constants';
 import { Receipt } from '../../../../../types/domain/receipt';
 import { PostReceiptResponse } from '../../../../../types/http/process-receipt';
 import { processReceiptController } from '../../../../controllers/process-receipt/process-receipt-controller';
 
 const PROCESS_RECEIPT_URL_PATH = `/${API_RECEIPTS_PATH}/${API_PROCESS_PATH}`;
 
-/**
- * A plugin that provides encapsulated routes
- * @param {FastifyInstance} fastify encapsulated fastify instance
- */
 export default async function processReceiptRoute(fastify: FastifyInstance) {
   fastify.post<{ Body: Receipt; Reply: PostReceiptResponse }>(
     PROCESS_RECEIPT_URL_PATH,
+    {
+      schema: {
+        description: 'Process a receipt and return an ID.',
+        body: { // Here, we define the request body schema for the POST request
+          type: 'object',
+          properties: {
+            retailer: { type: 'string' },
+            purchaseDate: { type: 'string', format: 'date' },
+            purchaseTime: { type: 'string', format: 'time' },
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  shortDescription: { type: 'string' },
+                  price: { type: 'string' },
+                },
+              },
+            },
+            total: { type: 'string' },
+          },
+        },
+        response: {
+          200: {
+            description: 'Successful response with receipt ID',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     processReceiptController
   );
 }

--- a/src/interface/routes/v1/receipts/process/route.ts
+++ b/src/interface/routes/v1/receipts/process/route.ts
@@ -16,8 +16,8 @@ export default async function processReceiptRoute(fastify: FastifyInstance) {
           type: 'object',
           properties: {
             retailer: { type: 'string' },
-            purchaseDate: { type: 'string', format: 'date' },
-            purchaseTime: { type: 'string', format: 'time' },
+            purchaseDate: { type: 'string' },
+            purchaseTime: { type: 'string' },
             items: {
               type: 'array',
               items: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,13 +2,27 @@ import { registerRoutes } from './interface/routes';
 import { createFastifyInstance } from './infrastructure/config/fastify-config';
 import { startServer } from './infrastructure/config/server-config';
 import { versionRedirectHook } from './interface/hooks/version-redirect-hook';
-import { registerSwagger, swaggerExample } from './infrastructure/config/swagger-config';
+import { registerSwagger } from './infrastructure/config/swagger-config';
 
 /**
  * Instantiate the Fastify server instance with custom configuration.
  * This is the core server instance used to handle all incoming requests.
  */
 const fastify = createFastifyInstance();
+
+/**
+ * Register the Swagger documentation for the API.
+ * This function integrates the Fastify Swagger plugin, which generates and serves
+ * API documentation based on the defined routes and their associated JSDoc comments.
+ *
+ * The Swagger documentation is accessible at the '/docs' route (adjusted from '/documentation'),
+ * This documentation includes information like:
+ * - Available endpoints and their HTTP methods
+ * - Request and response formats
+ * - Parameter descriptions
+ * - Response status codes and descriptions
+ */
+registerSwagger(fastify);
 
 /**
  * Define a basic health check route at the root ("/").
@@ -30,21 +44,6 @@ registerRoutes(fastify);
  * before processing incoming requests.
  */
 // fastify.addHook('onRequest', versionRedirectHook);
-
-/**
- * Register the Swagger documentation for the API.
- * This function integrates the Fastify Swagger plugin, which generates and serves
- * API documentation based on the defined routes and their associated JSDoc comments.
- *
- * The Swagger documentation is accessible at the '/docs' route (adjusted from '/documentation'),
- * This documentation includes information like:
- * - Available endpoints and their HTTP methods
- * - Request and response formats
- * - Parameter descriptions
- * - Response status codes and descriptions
- */
-// registerSwagger(fastify);
-// swaggerExample(fastify);
 
 /**
  * Add an endpoint to serve the OpenAPI spec as a JSON file.

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { registerRoutes } from './interface/routes';
 import { createFastifyInstance } from './infrastructure/config/fastify-config';
 import { startServer } from './infrastructure/config/server-config';
 import { versionRedirectHook } from './interface/hooks/version-redirect-hook';
+import { registerSwagger } from './infrastructure/config/swagger-config';
 
 /**
  * Instantiate the Fastify server instance with custom configuration.
@@ -28,7 +29,30 @@ registerRoutes(fastify);
  * In this case, the 'onRequest' hook is used to perform actions (e.g., redirects)
  * before processing incoming requests.
  */
-fastify.addHook('onRequest', versionRedirectHook);
+// fastify.addHook('onRequest', versionRedirectHook);
+
+/**
+ * Register the Swagger documentation for the API.
+ * This function integrates the Fastify Swagger plugin, which generates and serves
+ * API documentation based on the defined routes and their associated JSDoc comments.
+ *
+ * The Swagger documentation is accessible at the '/docs' route (adjusted from '/documentation'),
+ * This documentation includes information like:
+ * - Available endpoints and their HTTP methods
+ * - Request and response formats
+ * - Parameter descriptions
+ * - Response status codes and descriptions
+ */
+registerSwagger(fastify);
+
+/**
+ * Add an endpoint to serve the OpenAPI spec as a JSON file.
+ * This allows you to access the OpenAPI spec at `/openapi.json`.
+ */
+fastify.get('/openapi.json', async (request, reply) => {
+  const openapiSpec = fastify.swagger(); // Use fastify.swagger() to get the OpenAPI schema
+  reply.send(openapiSpec);
+});
 
 /**
  * Start the Fastify server and begin listening for incoming requests.

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,8 +49,8 @@ fastify.addHook('onRequest', versionRedirectHook);
  * Add an endpoint to serve the OpenAPI spec as a JSON file.
  * This allows you to access the OpenAPI spec at `/openapi.json`.
  */
-fastify.get('/openapi.json', async (request, reply) => {
-  const openapiSpec = fastify.swagger(); // Use fastify.swagger() to get the OpenAPI schema
+fastify.get('/openapi.json', async (_request, reply) => {
+  const openapiSpec = fastify.swagger();
   reply.send(openapiSpec);
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { registerRoutes } from './interface/routes';
 import { createFastifyInstance } from './infrastructure/config/fastify-config';
 import { startServer } from './infrastructure/config/server-config';
 import { versionRedirectHook } from './interface/hooks/version-redirect-hook';
-import { registerSwagger } from './infrastructure/config/swagger-config';
+import { registerSwagger, swaggerExample } from './infrastructure/config/swagger-config';
 
 /**
  * Instantiate the Fastify server instance with custom configuration.
@@ -43,7 +43,8 @@ registerRoutes(fastify);
  * - Parameter descriptions
  * - Response status codes and descriptions
  */
-registerSwagger(fastify);
+// registerSwagger(fastify);
+// swaggerExample(fastify);
 
 /**
  * Add an endpoint to serve the OpenAPI spec as a JSON file.

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,7 +43,7 @@ registerRoutes(fastify);
  * In this case, the 'onRequest' hook is used to perform actions (e.g., redirects)
  * before processing incoming requests.
  */
-// fastify.addHook('onRequest', versionRedirectHook);
+fastify.addHook('onRequest', versionRedirectHook);
 
 /**
  * Add an endpoint to serve the OpenAPI spec as a JSON file.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
     "rootDir": "./src",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": ["node_modules/@types", "node_modules/fastify-swagger"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Created Swagger UI to document endpoints

New dependencies:
- @fastify/swagger ^9 to generate openAPI spec from schemas
- @fastify/swagger-ui ^5 to serve the openAPI spec to a swagger ui

Add openApi schemas for both routes
Add all swagger configurations

Schema vailable at: localhost:3000/openapi.json
Swagger Docs available at: localhost:3000/docs
