### PR TITLE
Update crypto import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+dist/

--- a/src/utils/uuid-generator.ts
+++ b/src/utils/uuid-generator.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 /**
  * Generates a random UUID using the built-in `crypto.randomUUID()` method.
  *


### PR DESCRIPTION
 `crypto` module is a built-in Node.js module, but it's not globally available in all Node.js environments. While accessing crypto.randomUUID() was working in local dev and production environments, it was failing in Docker.

- Fix was to explicitly import the `crypto` module in generateRandomUUID()